### PR TITLE
[fix] avoid clippy warning clippy::needless_update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "typed_index_collection"
 description = "Manage collection of objects"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Kisio Digital <team.coretools@kisio.org>"]
 edition = "2018"
 license = "MIT"

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -43,7 +43,7 @@ macro_rules! impl_id {
 /// `name`. Both `id` and `name` will be set with the value of the input
 /// parameter `id`.
 /// ```
-/// # use typed_index_collection::impl_with_id;
+/// # use typed_index_collection::{impl_with_id, WithId};
 /// # fn main() {
 /// #[derive(Default)]
 /// struct Animal {
@@ -52,6 +52,10 @@ macro_rules! impl_id {
 ///   species: String,
 /// }
 /// impl_with_id!(Animal);
+/// let animal = Animal::with_id("cat");
+/// assert_eq!("cat", animal.id);
+/// assert_eq!("cat", animal.name);
+/// assert_eq!("", animal.species);
 /// # }
 /// ```
 #[macro_export]
@@ -59,11 +63,10 @@ macro_rules! impl_with_id {
     ($ty:ty) => {
         impl typed_index_collection::WithId for $ty {
             fn with_id(id: &str) -> Self {
-                Self {
-                    id: id.to_owned(),
-                    name: id.to_owned(),
-                    ..Default::default()
-                }
+                let mut r = Self::default();
+                r.id = id.to_owned();
+                r.name = id.to_owned();
+                r
             }
         }
     };


### PR DESCRIPTION
```
warning: struct update has no effect, all the fields in the struct have already been specified
   --> src/objects.rs:280:1
    |
280 | impl_with_id!(CommercialMode);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(clippy::needless_update)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_update
    = note: this warning originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
```