### PR TITLE
Clippy 1.49

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "typed_index_collection"
 description = "Manage collection of objects"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["Kisio Digital <team.coretools@kisio.org>"]
 edition = "2018"
 license = "MIT"

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -63,10 +63,11 @@ macro_rules! impl_with_id {
     ($ty:ty) => {
         impl typed_index_collection::WithId for $ty {
             fn with_id(id: &str) -> Self {
-                let mut r = Self::default();
-                r.id = id.to_owned();
-                r.name = id.to_owned();
-                r
+                Self {
+                    id: id.to_owned(),
+                    name: id.to_owned(),
+                    ..Default::default()
+                }
             }
         }
     };

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -62,6 +62,8 @@ macro_rules! impl_id {
 macro_rules! impl_with_id {
     ($ty:ty) => {
         impl typed_index_collection::WithId for $ty {
+            // This warning occurs when the type only has id and name members and no other
+            #[allow(clippy::needless_update)]
             fn with_id(id: &str) -> Self {
                 Self {
                     id: id.to_owned(),


### PR DESCRIPTION
Because it is a macro, the clippy warning occurs in the project where the library is used.