### PR TITLE
If there is a duplicated id, return in the error the object

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "typed_index_collection"
 description = "Manage collection of objects"
-version = "1.2.1"
+version = "1.3.0"
 authors = ["Kisio Digital <team.coretools@kisio.org>"]
 edition = "2018"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "typed_index_collection"
 description = "Manage collection of objects"
-version = "1.3.0"
+version = "2.0.0"
 authors = ["Kisio Digital <team.coretools@kisio.org>"]
 edition = "2018"
 license = "MIT"

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -12,8 +12,6 @@ use std::{
     ops, slice,
 };
 
-type Result<T, E = Error> = std::result::Result<T, E>;
-
 /// An object that can be assigned an identifier.
 pub trait WithId {
     /// Set an identifier and returns the object.
@@ -440,20 +438,26 @@ impl<T: Id<T>> CollectionWithId<T> {
     /// assert_eq!(2, c.len());
     /// assert_eq!(Some(&Obj("foo")), c.get("foo"));
     /// assert!(CollectionWithId::new(vec![Obj("foo"), Obj("foo")]).is_err());
-    pub fn new(v: Vec<T>) -> Result<Self> {
+    pub fn new(mut v: Vec<T>) -> std::result::Result<Self, Error<T>> {
         let mut id_to_idx = HashMap::default();
+        let mut existing_idx = None;
         for (i, obj) in v.iter().enumerate() {
             if id_to_idx
                 .insert(obj.id().to_string(), Idx::new(i))
                 .is_some()
             {
-                return Err(Error::IdentifierAlreadyExists(obj.id().to_owned()));
+                existing_idx = Some((i, obj.id().to_string()));
+                break;
             }
         }
-        Ok(CollectionWithId {
-            collection: Collection::new(v),
-            id_to_idx,
-        })
+        if let Some((idx, id)) = existing_idx {
+            Err(Error::IdentifierAlreadyExists(id, v.swap_remove(idx)))
+        } else {
+            Ok(CollectionWithId {
+                collection: Collection::new(v),
+                id_to_idx,
+            })
+        }
     }
 
     /// Get a reference to the `String` to `Idx<T>` internal mapping.
@@ -576,11 +580,11 @@ impl<T: Id<T>> CollectionWithId<T> {
     /// assert_eq!(&Obj("baz"), &c[baz_idx]);
     /// assert_eq!(&Obj("foobar"), &c[foobar_idx]);
     /// ```
-    pub fn push(&mut self, item: T) -> Result<Idx<T>> {
+    pub fn push(&mut self, item: T) -> std::result::Result<Idx<T>, Error<T>> {
         let next_index = self.collection.objects.len();
         let idx = Idx::new(next_index);
         match self.id_to_idx.entry(item.id().to_string()) {
-            Occupied(_) => Err(Error::IdentifierAlreadyExists(item.id().to_owned())),
+            Occupied(_) => Err(Error::IdentifierAlreadyExists(item.id().to_owned(), item)),
             Vacant(v) => {
                 v.insert(idx);
                 self.collection.objects.push(item);
@@ -644,7 +648,7 @@ impl<T: Id<T>> CollectionWithId<T> {
     /// c1.try_merge(c3);
     /// assert_eq!(4, c1.len());
     /// ```
-    pub fn try_merge(&mut self, other: Self) -> Result<()> {
+    pub fn try_merge(&mut self, other: Self) -> std::result::Result<(), Error<T>> {
         for item in other {
             self.push(item)?;
         }

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -440,24 +440,18 @@ impl<T: Id<T>> CollectionWithId<T> {
     /// assert!(CollectionWithId::new(vec![Obj("foo"), Obj("foo")]).is_err());
     pub fn new(mut v: Vec<T>) -> std::result::Result<Self, Error<T>> {
         let mut id_to_idx = HashMap::default();
-        let mut existing_idx = None;
         for (i, obj) in v.iter().enumerate() {
             if id_to_idx
                 .insert(obj.id().to_string(), Idx::new(i))
                 .is_some()
             {
-                existing_idx = Some(i);
-                break;
+                return Err(Error::IdentifierAlreadyExists(v.swap_remove(i)));
             }
         }
-        if let Some(idx) = existing_idx {
-            Err(Error::IdentifierAlreadyExists(v.swap_remove(idx)))
-        } else {
-            Ok(CollectionWithId {
-                collection: Collection::new(v),
-                id_to_idx,
-            })
-        }
+        Ok(CollectionWithId {
+            collection: Collection::new(v),
+            id_to_idx,
+        })
     }
 
     /// Get a reference to the `String` to `Idx<T>` internal mapping.

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -446,12 +446,12 @@ impl<T: Id<T>> CollectionWithId<T> {
                 .insert(obj.id().to_string(), Idx::new(i))
                 .is_some()
             {
-                existing_idx = Some((i, obj.id().to_string()));
+                existing_idx = Some(i);
                 break;
             }
         }
-        if let Some((idx, id)) = existing_idx {
-            Err(Error::IdentifierAlreadyExists(id, v.swap_remove(idx)))
+        if let Some(idx) = existing_idx {
+            Err(Error::IdentifierAlreadyExists(v.swap_remove(idx)))
         } else {
             Ok(CollectionWithId {
                 collection: Collection::new(v),
@@ -584,7 +584,7 @@ impl<T: Id<T>> CollectionWithId<T> {
         let next_index = self.collection.objects.len();
         let idx = Idx::new(next_index);
         match self.id_to_idx.entry(item.id().to_string()) {
-            Occupied(_) => Err(Error::IdentifierAlreadyExists(item.id().to_owned(), item)),
+            Occupied(_) => Err(Error::IdentifierAlreadyExists(item)),
             Vacant(v) => {
                 v.insert(idx);
                 self.collection.objects.push(item);

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,18 +2,18 @@ use thiserror::Error;
 
 #[derive(Error)]
 /// Typed error for `typed_index_collection`.
-pub enum Error<T> {
+pub enum Error<T: crate::collection::Id<T>> {
     /// This error occurs when an identifier already exists.
-    #[error("identifier {0} already exists")]
-    IdentifierAlreadyExists(String, T),
+    #[error("identifier {} already exists", .0.id())]
+    IdentifierAlreadyExists(T),
 }
 
-impl<T> std::fmt::Debug for Error<T> {
+impl<T: crate::collection::Id<T>> std::fmt::Debug for Error<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::IdentifierAlreadyExists(id, _) => f
+            Self::IdentifierAlreadyExists(obj) => f
                 .debug_struct("IdentifierAlreadyExists Error")
-                .field("id", &id)
+                .field("id", &obj.id())
                 .finish(),
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,21 @@ use thiserror::Error;
 
 #[derive(Error)]
 /// Typed error for `typed_index_collection`.
+/// ```
+/// # use typed_index_collection::{Error, Id};
+/// struct Object;
+/// impl Id<Object> for Object {
+///   fn id(&self) -> &str { "object_id" }
+///   fn set_id(&mut self, _: String) { todo!() }
+/// }
+/// let error = Error::IdentifierAlreadyExists(Object);
+/// let msg = format!("{:?}", error);
+/// // Output:
+/// // IdentifierAlreadyExists Error { id: "object_id", type: "Object" }
+/// # assert!(msg.contains("IdentifierAlreadyExists"));
+/// # assert!(msg.contains("object_id"));
+/// # assert!(msg.contains("Object"));
+/// ```
 pub enum Error<T: Id<T>> {
     /// This error occurs when an identifier already exists.
     #[error("identifier {} already exists", .0.id())]

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,6 +15,7 @@ impl<T: Id<T>> std::fmt::Debug for Error<T> {
             Self::IdentifierAlreadyExists(obj) => f
                 .debug_struct("IdentifierAlreadyExists Error")
                 .field("id", &obj.id())
+                .field("type", &std::any::type_name::<T>())
                 .finish(),
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,14 +1,15 @@
+use crate::collection::Id;
 use thiserror::Error;
 
 #[derive(Error)]
 /// Typed error for `typed_index_collection`.
-pub enum Error<T: crate::collection::Id<T>> {
+pub enum Error<T: Id<T>> {
     /// This error occurs when an identifier already exists.
     #[error("identifier {} already exists", .0.id())]
     IdentifierAlreadyExists(T),
 }
 
-impl<T: crate::collection::Id<T>> std::fmt::Debug for Error<T> {
+impl<T: Id<T>> std::fmt::Debug for Error<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::IdentifierAlreadyExists(obj) => f

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,9 +1,20 @@
 use thiserror::Error;
 
-#[derive(Error, Debug)]
+#[derive(Error)]
 /// Typed error for `typed_index_collection`.
-pub enum Error {
+pub enum Error<T> {
     /// This error occurs when an identifier already exists.
     #[error("identifier {0} already exists")]
-    IdentifierAlreadyExists(String),
+    IdentifierAlreadyExists(String, T),
+}
+
+impl<T> std::fmt::Debug for Error<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::IdentifierAlreadyExists(id, _) => f
+                .debug_struct("IdentifierAlreadyExists Error")
+                .field("id", &id)
+                .finish(),
+        }
+    }
 }


### PR DESCRIPTION
# The problem
We send an instance of an object `obj` of type `T: Id<T>` to `CollectionWithId::push()`. In case of an error (a duplicate identifier, which is the only possible error), we completely lose the original object which has been consumed, except for its identifier that is returned in an `Error::DuplicateIdentifier(String)`.

I believe in `std`, they tend to avoid leakage of information, the object would be returned, so the API caller can get back owned object to do something about it. Some API not directly showing the same use case but which are inspiring about that topic.

- [HashMap::insert()](https://doc.rust-lang.org/std/collections/struct.HashMap.html#method.insert) does return the existing entry if there was one, in order to not lose anything.
- [RefCell::replace()](https://doc.rust-lang.org/std/cell/struct.RefCell.html#method.replace) which also returns the inner value.

# Possible solution
Instead of returning `Error::DuplicateIdentifier(String)`, we could return `Error::DuplicateIdentifier(T)` directly, which would solve entirely the problem of `CollectionWithId::push()`.