### PR TITLE
[feature] add feature 'expose-inner' to expose some of the internals

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,6 @@ derivative = "2"
 serde = { version = "1", features = ["derive"] }
 log = "0.4"
 thiserror = "1"
+
+[features]
+expose-inner = []

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -1,4 +1,9 @@
 //! Collections of objects with typed indices and buildin identifier support.
+//!
+//! # Features
+//!
+//! With the feature `expose-inner`, you might be able to access information
+//! on some of the internals of the implementation.
 
 use crate::error::Error;
 use derivative::Derivative;
@@ -42,7 +47,21 @@ impl<T> Idx<T> {
     fn new(idx: usize) -> Self {
         Idx(idx as u32, PhantomData)
     }
+    #[cfg(not(feature = "expose-inner"))]
     fn get(self) -> usize {
+        self.0 as usize
+    }
+    #[cfg(feature = "expose-inner")]
+    /// Get the inner `usize` index of the object pointed to by the [`Idx<T>`] instance.
+    ///
+    /// Under the hood, [`CollectionWithId`] stores all the object in a [`Vec`],
+    /// the index being returned is therefore the position of the object inside this [`Vec`].
+    ///
+    /// # Warning
+    ///
+    /// Note that the real inner value is a [`u32`], then cast to a [`usize]`.
+    /// This might cause a `panic` on some platforms if the size of [`usize`] is smaller than a [`u32`].
+    pub fn get(self) -> usize {
         self.0 as usize
     }
 }


### PR DESCRIPTION
It might sometime be useful to be able to access internals of an `Idx` (and maybe other internals later). Especially, in this case, it's returning a copy of a value so no reference that might block a future mutable operation or a change of ownership.

Another solution would be to not do all of this behind a feature but exposing `get` directly in the main crate.