### PR TITLE
feat: add '.indexes()' iterator over indexes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "typed_index_collection"
 description = "Manage collection of objects"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Kisio Digital <team.coretools@kisio.org>"]
 edition = "2018"
 license = "MIT"

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -492,8 +492,37 @@ impl<T: Id<T>> CollectionWithId<T> {
     /// let c = CollectionWithId::new(vec![Obj("foo"), Obj("bar")]).unwrap();
     /// assert_eq!(2, c.len());
     /// assert_eq!(2, c.get_id_to_idx().len());
+    /// ```
     pub fn get_id_to_idx(&self) -> &HashMap<String, Idx<T>> {
         &self.id_to_idx
+    }
+
+    /// Iterate over the list of indexes of the [`CollectionWithId`].
+    ///
+    /// ```
+    /// use typed_index_collection::{CollectionWithId, Id};
+    /// use std::collections::HashMap;
+    ///
+    /// #[derive(PartialEq, Debug)]
+    /// struct Obj(&'static str);
+    ///
+    /// impl Id<Obj> for Obj {
+    ///     fn id(&self) -> &str { self.0 }
+    ///     fn set_id(&mut self, id: String) { unimplemented!(); }
+    /// }
+    ///
+    /// let c = CollectionWithId::new(vec![Obj("foo"), Obj("bar")]).unwrap();
+    /// let mut indexes = c.indexes();
+    /// let next_index = indexes.next().unwrap();
+    /// assert_eq!("foo", c[next_index].id());
+    /// let next_index = indexes.next().unwrap();
+    /// assert_eq!("bar", c[next_index].id());
+    /// assert_eq!(None, indexes.next());
+    /// ```
+    pub fn indexes(&self) -> impl Iterator<Item = Idx<T>> {
+        // NOTE: do not use `self.id_to_idx.values().copied()
+        // because `HashMap::values()` returns in randomized order
+        (0..self.collection.objects.len()).map(Idx::new)
     }
 
     /// Access to a mutable reference of the corresponding object.


### PR DESCRIPTION
Note that `HashMap` has a `.keys()` and `.values()` method. `CollectionWithId` has a `.values()` method, but nothing equivalent to `.keys()`. I chose to name it `.indexes()` instead of `.keys()` to keep consistent with the existing jargon.

This PR is a proposition to avoid the following pattern.

```rust
let indexes: Vec<Idx<SomeObject>> = some_collection
        .iter()
        .map(|(idx, _)| idx)
        .collect();
```

This could be done now with

```rust
let indexes: Vec<Idx<SomeObject>> = some_collection
        .indexes()
        .collect();
```
