### PR TITLE
fix: do not bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "typed_index_collection"
 description = "Manage collection of objects"
-version = "2.3.0"
+version = "2.2.0"
 authors = ["Kisio Digital <team.coretools@kisio.org>"]
 edition = "2018"
 license = "MIT"


### PR DESCRIPTION
I bumped `Cargo.toml` version to `2.3.0` in #15, but it was already bumped to `2.2.0` in #14 and version `2.2.0` was never released. This PR brings it back to `2.2.0`.