### PR TITLE
style: remove useless lifetimes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "typed_index_collection"
 description = "Manage collection of objects"
-version = "2.3.0"
+version = "2.3.1"
 authors = ["Hove <core@hove.com>"]
 edition = "2018"
 license = "MIT"

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -1071,18 +1071,18 @@ pub struct RefMut<'a, T: Id<T>> {
     collection: &'a mut CollectionWithId<T>,
     old_id: String,
 }
-impl<'a, T: Id<T>> ops::DerefMut for RefMut<'a, T> {
+impl<T: Id<T>> ops::DerefMut for RefMut<'_, T> {
     fn deref_mut(&mut self) -> &mut T {
         &mut self.collection.collection.objects[self.idx.get()]
     }
 }
-impl<'a, T: Id<T>> ops::Deref for RefMut<'a, T> {
+impl<T: Id<T>> ops::Deref for RefMut<'_, T> {
     type Target = T;
     fn deref(&self) -> &T {
         &self.collection.objects[self.idx.get()]
     }
 }
-impl<'a, T: Id<T>> Drop for RefMut<'a, T> {
+impl<T: Id<T>> Drop for RefMut<'_, T> {
     fn drop(&mut self) {
         if self.id() != self.old_id {
             self.collection.id_to_idx.remove(&self.old_id);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![deny(missing_docs)]
 // `derivative` does not implement `Clone` the correct way if it also implements `Copy`
-#![allow(clippy::incorrect_clone_impl_on_copy_type)]
+#![allow(clippy::non_canonical_clone_impl)]
 
 mod collection;
 mod error;


### PR DESCRIPTION
After applying some recent version of clippy, here are a few warnings that can be removed.